### PR TITLE
UI reflects rewards 👍 

### DIFF
--- a/src/hooks/useCalculateIncentives.tsx
+++ b/src/hooks/useCalculateIncentives.tsx
@@ -1,5 +1,5 @@
 import BigNumber from "bignumber.js";
-import { LoadingState, useAccount, useChronicle, useChronicleLastProcessedBlock, useIncentives, useOwnHasWonAnAuction } from "src/containers/store/Store"
+import { LoadingState, useAccount, useChronicle, useChronicleLastProcessedBlock, useIncentives, useOwnHasWonAnAuction, useOwn } from "src/containers/store/Store"
 import linearScale from 'simple-linear-scale';
 import config, { precisionMultiplierBN } from "src/config";
 import { Contribution, HistoricalIncentive } from "./useQueries";
@@ -121,7 +121,6 @@ export const calculateCurrentBsxReceived = (
         mostRecentAuctionClosingStart,
     );
     const totalContributionWeightBN = new BigNumber(totalContributionWeight)    
-        .dividedBy(precisionMultiplierBN);
 
     if (totalContributionWeightBN.isZero()) return new BigNumber(0);
 
@@ -192,12 +191,12 @@ export const useCalculateCurrentAccountMinimumBsxReceived = () => {
 export const useCalculateCurrentAccountCurrentBsxReceived = () => {
     const { data: { contributions } } = useAccount();
     const { data: { mostRecentAuctionClosingStart } } = useChronicle();
-    const { data: { totalContributionWeight } } = useIncentives();
+    const { parachain: { data: { fundsPledged: contributionWeightOfAllContributors } } } = useOwn();
 
     return calculateCurrentBsxReceived(
         contributions, 
         mostRecentAuctionClosingStart,
-        totalContributionWeight
+        String(contributionWeightOfAllContributors)
     );
 }
 

--- a/src/pages/Dashboard.scss
+++ b/src/pages/Dashboard.scss
@@ -170,6 +170,9 @@ $borderRadius: 8px;
             border-right: none;
             color: $green;
         }
+        .bsx-stat-border-right-none {
+            border-right: none;
+        }
     }
 }
 

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -37,7 +37,6 @@ const useDashboardData = () => {
 
     // incentives
     const { bsxMultiplier, hdxBonus } = useGlobalIncentives();
-    const currentAccountMinimumBsxReceived = useCalculateCurrentAccountMinimumBsxReceived();
     const currentAccountCurrentBsxReceived = useCalculateCurrentAccountCurrentBsxReceived();
     const currentAccountCurrentHdxReceived = useCalculateCurrentAccountHdxReceived()
     const ownHasWonAnAuction = useOwnHasWonAnAuction();
@@ -70,7 +69,6 @@ const useDashboardData = () => {
         // incentives
         bsxMultiplier,
         hdxBonus,
-        currentAccountMinimumBsxReceived,
         currentAccountCurrentBsxReceived,
         currentAccountCurrentHdxReceived,
         ownHasWonAnAuction
@@ -95,7 +93,6 @@ export const Dashboard = () => {
         // incentives
         bsxMultiplier,
         hdxBonus,
-        currentAccountMinimumBsxReceived,
         currentAccountCurrentBsxReceived,
         currentAccountCurrentHdxReceived,
         ownHasWonAnAuction
@@ -177,9 +174,9 @@ export const Dashboard = () => {
                     </div>
                 </div>
                 <div className="row bsx-stats">
-                    <div className="col-9">
+                    <div className="col-12">
                         <div className="row">
-                            <div className="col-3 bsx-stat">
+                            <div className="col-4 bsx-stat">
                                 <span className="bsx-stat-title">
                                     total ksm contributed
                                 </span>
@@ -187,17 +184,9 @@ export const Dashboard = () => {
                                     {millify(parseFloat(fromKsmPrecision(totalContributed)), millifyOptions)}
                                 </span>
                             </div>
-                            <div className="col-3 bsx-stat">
+                            <div className="col-4 bsx-stat">
                                 <span className="bsx-stat-title">
-                                    minimal bsx received
-                                </span>
-                                <span className="bsx-stat-value">
-                                    {millify(parseFloat(fromKsmPrecision(currentAccountMinimumBsxReceived)), millifyOptions)}
-                                </span>
-                            </div>
-                            <div className="col-3 bsx-stat">
-                                <span className="bsx-stat-title">
-                                    current bsx received
+                                    bsx reward
                                 </span>
                                 <span className="bsx-stat-value">
                                     {currentAccountCurrentBsxReceived
@@ -206,23 +195,15 @@ export const Dashboard = () => {
                                     }
                                 </span>
                             </div>
-                            <div className="col-3 bsx-stat">
+                            <div className="col-4 bsx-stat bsx-stat-border-right-none">
                                 <span className="bsx-stat-title">
-                                    current hdx reward
+                                    hdx reward
                                 </span>
                                 <span className="bsx-stat-value">
                                     {millify(parseFloat(usdToHdx(ksmToUsd(fromKsmPrecision(currentAccountCurrentHdxReceived)))), millifyOptions)}
                                 </span>
-                            </div>
+                            </div>   
                         </div>
-                    </div>
-                    <div className="col-3 bsx-stat bsx-stat-balance">
-                        <span className="bsx-stat-title">
-                            free balance
-                        </span>
-                        <span className="bsx-stat-value">
-                            {millify(parseFloat(fromKsmPrecision(activeAccountBalance)), millifyOptions)}
-                        </span>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
(final?) Decisions that lead to this PR:

-  Just use $400 fixed KSM price for HDX reward calculation.  
   -  **we already use a $400 fixed KSM price here on the FE,  so we don't need to change anything to accomodate this** 
   -  see https://github.com/galacticcouncil/Basilisk-crowdloan-ui/pull/19 to see the rewards script and JSON data for this ☝️ 

-  All contributions get BSX at max incentives.  
   -  the code in this PR addresses this;  from my testing etc.,  the error on the FE occurs because the query used previous to this PR was not returning the full `totalContributionWeight`.
   -  we don't know why the processor is not returning the full crowdloan weight of KSM that was conributed.   We need to understand the bug so that we do not make the same mistake during the HDX crowdloan,  but 👉  for the purposes of updating the BSX crowdloan UI here,  we can use the fix in this PR,  and tackle the bug in the processor separately.
   
** *see more of the discussion that led to this in the previous comments in the files.  At https://github.com/galacticcouncil/Basilisk-crowdloan-ui/pull/18 you can see a comparision of HDX rewards using different methods of deciding what KSM price to use in the HDX calculation**